### PR TITLE
Remove Ruby Warriors as it redirects to chegg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,6 @@
 - [Java](#java)
 - [JavaScript](#javascript)
 - [C Sharp](#c-sharp)
-- [Ruby](#ruby)
 - [Assembly](#assembly)
 - [Scala](#scala)
 - [Miscellaneous](#miscellaneous)
@@ -50,11 +49,6 @@
 
 - [Robocode](http://robocode.sourceforge.io/robocode.dotnet) - The goal is to develop a robot battle tank to battle against other tanks. The robot battles are running in real-time and on-screen.
 - [Code Hero](http://www.codehero.org) - A first-person coding puzzle platformer that equips you with a code ray that casts C# at your target.
-
-
-## Ruby
-
-- [RubyWarrior](https://www.bloc.io/ruby-warrior) - A browser based game where you control your avatar through various levels filled with enemies using Ruby.
 
 ## Assembly
 


### PR DESCRIPTION
Meant to address this comment:
https://github.com/michelpereira/awesome-games-of-coding/issues/50#issuecomment-1783940061

The game I'm removing here currently redirects to Chegg.

**Edit:**
I didn't play the original, but it does look like there's an unofficial fork/deployed version of this game running here:
https://palkan.github.io/ruby-warrior/

Should I update to link to that instead?